### PR TITLE
Create parent directories on initial installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ if [ -d "$DIR/latex/$PACKAGE_NAME" ]; then
 	copy_files $DIR/latex/$PACKAGE_NAME
 else
 	echo "Initial installation. Copying files:"
-	mkdir $DIR/latex/$PACKAGE_NAME
+	mkdir -p $DIR/latex/$PACKAGE_NAME
 	copy_files $DIR/latex/$PACKAGE_NAME
 fi
 


### PR DESCRIPTION
Problem

Some of the proposed installation paths are deeply nested and
several levels of directories might not exist, which leads to a
failing installation.

Solution

Use the `-p` flag with `mkdir`.
