### PR TITLE
Fixed compile bug

### DIFF
--- a/uulm-exam.cls
+++ b/uulm-exam.cls
@@ -242,13 +242,11 @@ Korrektur-Status:\\[2pt]
 		\uulmlogo{black}{true}
 	}%
 
-	%\vfill
 	\small
 	\begin{center}
 		\Large{Klausur \textbf{\@title}}
 	\end{center}
-	%\vfill
-	
+
 	\colorbox{hellgrau}{
 		\begin{minipage}{\textwidth-1.2em}
 			\begin{tabular}{llll}


### PR DESCRIPTION
After e29efd7, a bug was introduced that caused the second compile run to fail when the boolean showsubtaskboxes was set. This is now corrected, and I've verified that the template looks as it should (thanks @sschober, @berb).
